### PR TITLE
Fix: Ensure cart checkout area is scrollable on desktop

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -635,7 +635,8 @@ span.text-red {
   transition: all 1s ease-in-out;
 }
 .cart-container {
-  height: 100vh;
+  height: calc(100vh - var(--navbar-height));
+  top: var(--navbar-height);
   width: 600px;
   background-color: var(--primary-background-color); /* Was white */
   float: right;
@@ -709,7 +710,7 @@ span.text-red {
 .product-container {
   margin-top: 15px;
   overflow: auto;
-  max-height: 70vh;
+  max-height: calc(100% - 180px); /* Adjusted to account for cart heading and cart-bottom more accurately */
   padding: 20px 10px;
   background-color: var(--primary-background-color); 
 }


### PR DESCRIPTION
The sticky navbar was previously causing the cart container (with 100vh height) to extend beyond the viewport, hiding the checkout section.

This commit adjusts the cart's CSS:
- Sets `.cart-container` height to `calc(100vh - var(--navbar-height))` and positions it below the navbar using `top: var(--navbar-height)`.
- Adjusts `max-height` of the scrollable `.product-container` within the cart to `calc(100% - 180px)` to properly fit between the cart header and the checkout area.

These changes allow the product list in the cart to scroll independently while keeping the checkout area visible on desktop views, without altering the overall design.