### PR TITLE
Fix: Make cart bottom sheet full width on desktop

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -636,9 +636,8 @@ span.text-red {
 }
 .cart-container {
   height: 100vh;
-  width: 600px;
+  width: 100vw;
   background-color: var(--primary-background-color); /* Was white */
-  float: right;
   position: relative;
   color: var(--text-color); 
   padding: 30px 15px; /* Consolidated padding, this was the effective one */


### PR DESCRIPTION
The cart bottom sheet was previously fixed to a width of 600px and floated to the right on desktop views. This change modifies `styles/globals.css` to allow the cart to expand to the full viewport width (`100vw`) on desktop.

Specifically, I removed the `width: 600px` and `float: right` properties from the `.cart-container` class for desktop screen sizes. I also added `width: 100vw`.

Existing media queries ensure that the cart's appearance and behavior on mobile devices remain unchanged. No adjustments were necessary for the Material UI Drawer component in `components/Cart.jsx` as it did not impose conflicting width styles.

You should manually confirm:
- Cart is full width on various desktop screen sizes.
- Cart maintains its original, appropriate styling on mobile screen sizes.
- No layout issues or regressions in other parts of the application.