### PR TITLE
Fix: Use NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY for ClerkProvider

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -123,7 +123,7 @@ export default function App({ Component, pageProps }) {
 
   return (
     <ClerkProvider
-      frontendApi={process.env.NEXT_PUBLIC_CLERK_FRONTEND_API}
+      publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
       appearance={clerkAppearance}
     >
       <StateContext>


### PR DESCRIPTION
Updated `pages/_app.js` to use `process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` for initializing the ClerkProvider. This aligns with current Clerk recommendations and aims to resolve issues with UI elements not appearing in deployment due to incorrect environment variable configuration.