### PR TITLE
Fix: Correct UserButton behavior and re-enable Clerk theming

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -261,12 +261,12 @@ const Navbar = () => {
               <li onClick={() => selectTheme('dark')}>Dark Theme</li>
               <li onClick={() => selectTheme('rgb')}>RGB Theme</li>
               <SignedIn>
-                <li>
+                <li onClick={(e) => e.stopPropagation()}>
                   <UserButton afterSignOutUrl="/" />
                 </li>
               </SignedIn>
               <SignedOut>
-                <li>
+                <li onClick={(e) => e.stopPropagation()}>
                   <SignInButton
                     mode="modal"
                   >

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
 import { AiOutlineShopping } from 'react-icons/ai';
 import { FiSun, FiMoon, FiDroplet, FiMoreHorizontal } from 'react-icons/fi'; // Import Feather icons
-import { UserButton, SignInButton, SignedIn, SignedOut } from '@clerk/nextjs';
+import { useUser, UserButton, SignInButton } from '@clerk/nextjs';
 
 import { Cart } from './';
 import { useStateContext } from '../context/StateContext';
@@ -57,6 +57,7 @@ const Navbar = () => {
   const [showThemeMenu, setShowThemeMenu] = useState(false);
   const themeMenuRef = useRef(null); // For detecting clicks outside
   const [isScrolled, setIsScrolled] = useState(false);
+  const { isLoaded, isSignedIn } = useUser();
 
   const applyRgbTheme = useCallback((selectedRgbColor) => {
     const mainContrastColor = calculateContrastColor(selectedRgbColor);
@@ -260,23 +261,28 @@ const Navbar = () => {
               <li onClick={() => selectTheme('light')}>Light Theme</li>
               <li onClick={() => selectTheme('dark')}>Dark Theme</li>
               <li onClick={() => selectTheme('rgb')}>RGB Theme</li>
-              <SignedIn>
-                <li onClick={(e) => e.stopPropagation()}>
-                  <UserButton afterSignOutUrl="/" />
-                </li>
-              </SignedIn>
-              <SignedOut>
-                <li onClick={(e) => e.stopPropagation()}>
-                  <SignInButton
-                    mode="modal"
-                  >
-                    {/* This span helps if SignInButton doesn't take full width or needs text styling like other li items */}
-                    <span style={{ display: 'block', width: '100%', cursor: 'pointer' }}>
-                      Sign In
-                    </span>
-                  </SignInButton>
-                </li>
-              </SignedOut>
+              {isLoaded && (
+                <>
+                  {isSignedIn ? (
+                    <li onClick={(e) => e.stopPropagation()}>
+                      <UserButton afterSignOutUrl="/" />
+                    </li>
+                  ) : (
+                    <li onClick={(e) => e.stopPropagation()}>
+                      <SignInButton
+                        mode="modal"
+                      >
+                        {/* This span helps if SignInButton doesn't take full width or needs text styling like other li items */}
+                        <span style={{ display: 'block', width: '100%', cursor: 'pointer' }}>
+                          Sign In
+                        </span>
+                      </SignInButton>
+                    </li>
+                  )}
+                </>
+              )}
+              {/* Optionally, add a placeholder for !isLoaded if desired */}
+              {/* {!isLoaded && <li>Loading...</li>} */}
             </ul>
           )}
         </div>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,7 +7,7 @@ import { dark } from "@clerk/themes"; // Import a base theme if you want to use 
 
 export default function App({ Component, pageProps }) {
   const clerkAppearance = {
-    baseTheme: undefined, // Can be `dark` or light (default) or undefined to use system preference
+    baseTheme: dark, // Can be `dark` or light (default) or undefined to use system preference
     variables: {
       // General
       colorPrimary: "var(--primary-color)",
@@ -124,7 +124,7 @@ export default function App({ Component, pageProps }) {
   return (
     <ClerkProvider
       publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
-      // appearance={clerkAppearance}
+      appearance={clerkAppearance}
     >
       <StateContext>
         <Layout>


### PR DESCRIPTION
- I modified Navbar.jsx to stop event propagation on UserButton/SignInButton list items, allowing Clerk menus/modals to open correctly from within the dropdown.
- I re-enabled and updated the 'appearance' prop in ClerkProvider in _app.js to apply custom theming (with baseTheme: dark for testing).

Ready for you to test the UserButton functionality and modal theming.