### PR TITLE
feat: Implement Clerk theme synchronization with next-themes

### DIFF
--- a/components/ClerkThemeProvider.jsx
+++ b/components/ClerkThemeProvider.jsx
@@ -1,0 +1,122 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import { ClerkProvider } from '@clerk/nextjs';
+import { dark } from '@clerk/themes';
+import { useTheme } from 'next-themes';
+
+// This is the clerkAppearance object copied from pages/_app.js
+const baseClerkAppearance = {
+  baseTheme: undefined,
+  variables: {
+    // General
+    colorPrimary: "var(--primary-color)",
+    colorBackground: "var(--primary-background-color)",
+    colorText: "var(--text-color)",
+    colorInputBackground: "var(--secondary-background-color)",
+    colorInputText: "var(--text-color)",
+    // Cards & Modals
+    colorBackgroundMuted: "var(--glass-background-color)",
+    colorNeutralMuted: "var(--glass-background-color)",
+    colorNeutral: "var(--glass-border-color)",
+    // Buttons
+    colorDanger: "var(--primary-color)",
+    colorSuccess: "var(--plus-color)",
+  },
+  elements: {
+    card: {
+      backgroundColor: "var(--glass-background-color)",
+      borderColor: "var(--glass-border-color)",
+      boxShadow: "0 8px 32px 0 var(--glass-box-shadow-color)",
+      borderRadius: "10px",
+    },
+    modalContent: {
+      backgroundColor: "transparent",
+    },
+    modalBackdrop: "rgba(0, 0, 0, 0.5)",
+    formButtonPrimary: {
+      backgroundColor: "var(--primary-color)",
+      color: "var(--text-on-primary-color)",
+      '&:hover': {
+        backgroundColor: "var(--secondary-color)",
+      },
+    },
+    formFieldInput: {
+      backgroundColor: "var(--secondary-background-color)",
+      color: "var(--text-color)",
+      borderColor: "var(--glass-border-color)",
+      '&:focus': {
+        borderColor: "var(--primary-color)",
+        boxShadow: "0 0 0 1px var(--primary-color)",
+      }
+    },
+    headerTitle: { color: "var(--text-color)" },
+    headerSubtitle: { color: "var(--text-color)" },
+    bodyText: { color: "var(--text-color)" },
+    footerActionText: { color: "var(--text-color)" },
+    footerActionLink: {
+      color: "var(--primary-color)",
+      '&:hover': { color: "var(--secondary-color)" }
+    },
+    dividerLine: { backgroundColor: "var(--glass-border-color)" },
+    dividerText: { color: "var(--text-color)" },
+    formFieldLabel: { color: "var(--text-color)" },
+    socialButtonsBlockButton: {
+      borderColor: "var(--glass-border-color)",
+      '&:hover': { backgroundColor: "var(--secondary-background-color)" }
+    },
+    selectButton: {
+      borderColor: "var(--glass-border-color)",
+      '&:hover': { backgroundColor: "var(--secondary-background-color)" }
+    },
+    selectOptionsContainer: {
+      backgroundColor: "var(--secondary-background-color)",
+      borderColor: "var(--glass-border-color)",
+    },
+    selectOption__selected: {
+      backgroundColor: "var(--primary-color)",
+      color: "var(--text-on-primary-color)",
+    },
+    selectOption: {
+      '&:hover': {
+        backgroundColor: "var(--primary-color)",
+        color: "var(--text-on-primary-color)",
+      }
+    },
+    badge: {
+      backgroundColor: "var(--secondary-background-color)",
+      color: "var(--text-color)",
+      borderColor: "var(--glass-border-color)",
+    }
+  }
+};
+
+export function ClerkThemeProvider({ children, ...props }) {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Start with the base appearance
+  let dynamicClerkAppearance = { ...baseClerkAppearance };
+
+  if (mounted) {
+    dynamicClerkAppearance.baseTheme = resolvedTheme === 'dark' ? dark : undefined;
+  } else {
+    // While not mounted, we might want to ensure baseTheme is explicitly undefined
+    // or set to a default that doesn't rely on client-side resolution yet.
+    // The current baseClerkAppearance already has baseTheme: undefined, so this is fine.
+  }
+
+  // If props contains a specific appearance object from _app.js (it shouldn't anymore with this pattern),
+  // this might need more nuanced merging. However, the goal is for this component to *be* the source of truth for appearance.
+  // The publishableKey and other direct ClerkProvider props will be passed via ...props.
+
+  return (
+    <ClerkProvider {...props} appearance={mounted ? dynamicClerkAppearance : baseClerkAppearance}>
+      {children}
+    </ClerkProvider>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "canvas-confetti": "^1.5.1",
         "next": "13.5.6",
         "next-sanity-image": "^6.0.0",
+        "next-themes": "^0.4.6",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-hot-toast": "^2.2.0",
@@ -2158,6 +2159,16 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
@@ -6786,6 +6797,15 @@
         "react": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -8648,6 +8668,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "canvas-confetti": "^1.5.1",
     "next": "13.5.6",
     "next-sanity-image": "^6.0.0",
+    "next-themes": "^0.4.6",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-hot-toast": "^2.2.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,136 +2,27 @@ import { Layout } from "../components";
 import "../styles/globals.css";
 import { StateContext } from "../context/StateContext";
 import { Toaster } from "react-hot-toast";
-import { ClerkProvider } from "@clerk/nextjs";
-import { dark } from "@clerk/themes"; // Import a base theme if you want to use one
+// import { ClerkProvider } from "@clerk/nextjs"; // Replaced by ClerkThemeProvider
+import { ThemeProvider } from 'next-themes';
+// import { dark } from "@clerk/themes"; // This is now handled in ClerkThemeProvider
+import { ClerkThemeProvider } from '../components/ClerkThemeProvider';
 
 export default function App({ Component, pageProps }) {
-  const clerkAppearance = {
-    baseTheme: undefined, // Can be `dark` or light (default) or undefined to use system preference
-    variables: {
-      // General
-      colorPrimary: "var(--primary-color)",
-      colorBackground: "var(--primary-background-color)",
-      colorText: "var(--text-color)",
-      colorInputBackground: "var(--secondary-background-color)",
-      colorInputText: "var(--text-color)",
-
-      // Cards & Modals (using glassmorphism variables)
-      colorBackgroundMuted: "var(--glass-background-color)", // For card backgrounds
-      colorNeutralMuted: "var(--glass-background-color)", // for modal backdrop
-      colorNeutral: "var(--glass-border-color)", // for borders
-
-      // Buttons
-      colorDanger: "var(--primary-color)", // Example for destructive actions
-      colorSuccess: "var(--plus-color)", // Example for success actions
-
-      // Specific Clerk component elements
-      // You might need to inspect Clerk components to find the exact variables they use if not covered by globals
-    },
-    elements: {
-      card: { // This is the main container for the sign-in/up form
-        backgroundColor: "var(--glass-background-color)",
-        borderColor: "var(--glass-border-color)",
-        boxShadow: "0 8px 32px 0 var(--glass-box-shadow-color)",
-        borderRadius: "10px", // Consistent with .glassmorphism class
-      },
-      modalContent: { // modalContent often wraps the card
-        backgroundColor: "transparent", // Make it transparent if card is already glassmorphism
-        // borderColor: "var(--glass-border-color)", // card will handle its own border
-        // boxShadow: "none", // card will handle its own shadow
-      },
-      modalBackdrop: "rgba(0, 0, 0, 0.5)", // Standard semi-transparent dark backdrop
-      formButtonPrimary: {
-        backgroundColor: "var(--primary-color)",
-        color: "var(--text-on-primary-color)", // Assuming you have this for text on primary buttons
-        '&:hover': {
-          backgroundColor: "var(--secondary-color)", // Example: darken on hover
-        },
-      },
-      formFieldInput: {
-        backgroundColor: "var(--secondary-background-color)",
-        color: "var(--text-color)",
-        borderColor: "var(--glass-border-color)",
-        '&:focus': {
-          borderColor: "var(--primary-color)",
-          boxShadow: "0 0 0 1px var(--primary-color)",
-        }
-      },
-      headerTitle: {
-        color: "var(--text-color)",
-      },
-      headerSubtitle: {
-        color: "var(--text-color)",
-      },
-      bodyText: {
-        color: "var(--text-color)",
-      },
-      footerActionText: {
-        color: "var(--text-color)",
-      },
-      footerActionLink: {
-        color: "var(--primary-color)",
-        '&:hover': {
-          color: "var(--secondary-color)", // Example: darken on hover
-        }
-      },
-      dividerLine: {
-        backgroundColor: "var(--glass-border-color)",
-      },
-      dividerText: {
-        color: "var(--text-color)",
-      },
-      formFieldLabel: {
-        color: "var(--text-color)",
-      },
-      socialButtonsBlockButton: { // For "Continue with X"
-        borderColor: "var(--glass-border-color)",
-        '&:hover': {
-          backgroundColor: "var(--secondary-background-color)",
-        }
-      },
-      socialButtonsProviderIcon: {
-        // color: "var(--text-color)" // if you want to theme the provider icons
-      },
-      selectButton: {
-        borderColor: "var(--glass-border-color)",
-        '&:hover': {
-          backgroundColor: "var(--secondary-background-color)",
-        }
-      },
-      selectOptionsContainer: {
-        backgroundColor: "var(--secondary-background-color)",
-        borderColor: "var(--glass-border-color)",
-      },
-      selectOption__selected: {
-        backgroundColor: "var(--primary-color)",
-        color: "var(--text-on-primary-color)",
-      },
-      selectOption: {
-        '&:hover': {
-          backgroundColor: "var(--primary-color)",
-          color: "var(--text-on-primary-color)",
-        }
-      },
-      badge: {
-        backgroundColor: "var(--secondary-background-color)",
-        color: "var(--text-color)",
-        borderColor: "var(--glass-border-color)",
-      }
-    }
-  };
+  // const clerkAppearance = { ... }; // This object is now defined and managed within ClerkThemeProvider
 
   return (
-    <ClerkProvider
-      publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
-      // appearance={clerkAppearance}
-    >
-      <StateContext>
-        <Layout>
-          <Toaster />
-          <Component {...pageProps} />
-        </Layout>
-      </StateContext>
-    </ClerkProvider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <ClerkThemeProvider
+        publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+        {...pageProps} // Spread pageProps to pass __clerk_ssr_state and other props
+      >
+        <StateContext>
+          <Layout>
+            <Toaster />
+            <Component {...pageProps} />
+          </Layout>
+        </StateContext>
+      </ClerkThemeProvider>
+    </ThemeProvider>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -64,7 +64,7 @@
   --clr-btn-primary-hover-bg: var(--primary-color-hover);
 }
 
-.dark-mode {
+html.dark {
   --text-on-primary-color: var(--background-light); /* Text on primary color (red) is still light in dark mode */
   --text-color: var(--text-color-dark);
   --primary-background-color: var(--background-dark);
@@ -76,7 +76,7 @@
   --product-card-hover-shadow: var(--product-card-hover-shadow-dark);
 }
 
-.rgb-mode {
+html.rgb {
   --text-color: var(--text-color-rgb);
   --primary-background-color: var(--primary-background-color-rgb);
   --secondary-background-color: var(--secondary-background-color-rgb);
@@ -178,11 +178,11 @@ a {
      This class specifically overrides the background for the scrolled state. */
 }
 
-.dark-mode .scrolled-navbar {
+html.dark .scrolled-navbar {
   background: var(--scrolled-navbar-bg-dark) !important;
 }
 
-.rgb-mode .scrolled-navbar {
+html.rgb .scrolled-navbar {
   background: var(--scrolled-navbar-bg-rgb) !important;
 }
 


### PR DESCRIPTION
This commit integrates `next-themes` to allow dynamic theming (light/dark/system) of Clerk components in synchronization with the rest of your application.

Key changes:
- Installed `next-themes` package.
- Added `ThemeProvider` from `next-themes` to `pages/_app.js`, configured for class-based theming.
- Created a new `ClerkThemeProvider` component (`components/ClerkThemeProvider.jsx`):
    - This component acts as a bridge between `next-themes` and Clerk.
    - It uses the `useTheme` hook from `next-themes` to get the current theme.
    - Dynamically applies the `dark` base theme from `@clerk/themes` to Clerk components when your application theme is dark.
    - Preserves and utilizes the existing detailed custom `clerkAppearance` settings, which rely on CSS variables for styling.
    - Includes client-side mount detection to prevent hydration mismatches.
- Integrated `ClerkThemeProvider` into `pages/_app.js`, replacing the direct use of `ClerkProvider` and centralizing Clerk theme logic.
- Updated `styles/globals.css` to use `html.dark` (and `html.rgb`) selectors for dark mode (and RGB mode) CSS variable overrides. This makes the global stylesheet compatible with `next-themes` when `attribute="class"` is used.

Clerk components (sign-in, sign-up, etc.) should now respect your application's theme set via `next-themes`, and their appearance will be consistent with the custom styles defined.